### PR TITLE
Added token generation compatibility for Linux & MacOS

### DIFF
--- a/PSGuacamole/Public/APIConnection/New-GuacToken.ps1
+++ b/PSGuacamole/Public/APIConnection/New-GuacToken.ps1
@@ -39,16 +39,22 @@ Function New-GuacToken()
         if ($Null -eq $Password -or $Password.Length -eq 0)
         {
             $SecurePassword = Read-Host "Enter password" -AsSecureString
-
-            # Decode SecureString to Plain text for Guacamole (https://www.powershelladmin.com/wiki/Powershell_prompt_for_password_convert_securestring_to_plain_text)
-            # Create a "password pointer"
-            $PasswordPointer = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecurePassword)
-
-            # Get the plain text version of the password
-            $Password = [Runtime.InteropServices.Marshal]::PtrToStringAuto($PasswordPointer)
-
-            # Free the pointer
-            [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($PasswordPointer)
+            # If running on Windows
+            if ($IsWindows)
+            {
+                # Decode SecureString to Plain text for Guacamole (https://www.powershelladmin.com/wiki/Powershell_prompt_for_password_convert_securestring_to_plain_text)
+                # Create a "password pointer"
+                $PasswordPointer = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecurePassword)
+    
+                # Get the plain text version of the password
+                $Password = [Runtime.InteropServices.Marshal]::PtrToStringAuto($PasswordPointer)
+    
+                # Free the pointer
+                [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($PasswordPointer)
+            # If running on Linux of MacOS
+            } else {
+                $Password = ConvertFrom-SecureString -SecureString $SecurePassword -AsPlaintext
+            }
         }
 
         $Body = @{


### PR DESCRIPTION
Linux and MacOS use UTF-8 rather than Windows Powershell UTF-16.  Due to the extra null bytes from UTF-16, password conversion from SecureString to plaintext was terminating after the first character on Linux.  This commit adds a check to determine if the host system is Windows or Linux/MacOS.  If Windows, the original logic runs.  If Linux or MacOS, a different method for converting a SecureString to plaintext is performed.